### PR TITLE
Improved Logging, Reorganized, Changed Modify Behaviour

### DIFF
--- a/COMMON.py
+++ b/COMMON.py
@@ -14,6 +14,7 @@ class Common:
     sessionFile = "cookies.session"
     persistenceFile = "user.persistence"
     vrfList = "vrf.list"
+    dataDirectory = "larry-data"
     ignoreDirectories = [".git", ".idea", "risque-out"]
     changelogURL = "https://github.com/Changer098/larry/blob/master/CHANGELOG.md"
     __vrfHosts = None

--- a/COMMON.py
+++ b/COMMON.py
@@ -14,7 +14,7 @@ class Common:
     sessionFile = "cookies.session"
     persistenceFile = "user.persistence"
     vrfList = "vrf.list"
-    dataDirectory = "larry-data"
+    dataDirectory = "larry-data/"
     ignoreDirectories = [".git", ".idea", "risque-out"]
     changelogURL = "https://github.com/Changer098/larry/blob/master/CHANGELOG.md"
     __vrfHosts = None

--- a/Logger.py
+++ b/Logger.py
@@ -3,16 +3,19 @@ import time
 import os
 import traceback
 import sys
+import datetime
 
 
 class Logger:
     logFolder = None
     ticketNumber = None
     sshLogFile = None
+    beforeAfterFile = None
     logFile = None
     ticketFolder = None
     instance = None
     disableColor = False
+    beforeAfterConfigs = dict() # dict(picName) -> [beforeConfig, afterConfig]
 
     # colors
     WARNING = '\033[93m'
@@ -26,22 +29,37 @@ class Logger:
         if noLogging:
             self.logFile = sys.stdout
             self.sshLogFile = sys.stdout
+            self.beforeAfterFile = sys.stdout
         else:
             if logFolder is None:
-                self.logFolder = Common.getUserHome() + Common.dataDirectory + "/logs/"
+                self.logFolder = Common.getUserHome() + Common.dataDirectory + "logs/"
             else:
                 self.logFolder = logFolder
             self.ticketFolder = self.logFolder + str(ticketNumber) + "/"
             self.__createFolders()
             self.logFile = open(self.ticketFolder + "log.log", "a+")
             self.sshLogFile = open(self.ticketFolder + "ssh.log", "a+")
+            self.beforeAfterFile = open(self.ticketFolder + "beforeAfter.log", "a+")
+            self.__writeHeaders()
         Logger.instance = self
 
     def __createFolders(self):
+        if not os.path.isdir(Common.getUserHome() + Common.dataDirectory):
+            os.mkdir(Common.getUserHome() + Common.dataDirectory)
         if not os.path.isdir(self.logFolder):
             os.mkdir(self.logFolder)
         if not os.path.isdir(self.ticketFolder):
             os.mkdir(self.ticketFolder)
+
+    def __writeHeaders(self):
+        if self.logFile is not sys.stdout:
+            # write Log File Headers
+            self.logFile.writelines(
+                ["#### larry|Log ####\n", "# {0} #\n".format(Logger.getTimeStamp()), "###################\n"])
+            self.sshLogFile.writelines(
+                ["#### larry|SSH Log ####\n", "# {0} #\n".format(Logger.getTimeStamp()), "###################\n"])
+            self.beforeAfterFile.writelines(
+                ["#### larry|Before And After ####\n", "# {0} #\n".format(Logger.getTimeStamp()), "###################\n"])
 
     def logSSH(self, string):
         self.sshLogFile.write("|{0}| - {1}\n".format(self.getTimeStamp(), string))
@@ -60,6 +78,48 @@ class Logger:
         if echo:
             # print self.FAIL + "ERROR " + string
             self.printError(string)
+
+    def logBefore(self, picName, interface, config):
+        if picName not in self.beforeAfterConfigs:
+            self.beforeAfterConfigs[picName] = [None, None]
+        if self.beforeAfterConfigs[picName] is None:
+            return
+        self.beforeAfterConfigs[picName][0] = config
+        if self.beforeAfterConfigs[picName][0] is not None and self.beforeAfterConfigs[picName][1] is not None:
+            # write out the configs
+            self.beforeAfterFile.write("\t {1}:{0} Before\n".format(picName, interface))
+            #
+            # This is I/O bottle-necked. A bulk write() would be more efficient, or writelines(). writelines() doesn't
+            # append new lines though.
+            #
+            for line in self.beforeAfterConfigs[picName][0]:
+                self.beforeAfterFile.write(line + '\n')
+            self.beforeAfterFile.write("\t {1}:{0} After\n".format(picName, interface))
+            for line in self.beforeAfterConfigs[picName][1]:
+                self.beforeAfterFile.write(line + '\n')
+            self.beforeAfterConfigs[picName] = None
+            self.beforeAfterFile.flush()
+
+    def logAfter(self, picName, interface, config):
+        if picName not in self.beforeAfterConfigs:
+            self.beforeAfterConfigs[picName] = [None, None]
+        if self.beforeAfterConfigs[picName] is None:
+            return
+        self.beforeAfterConfigs[picName][1] = config
+        if self.beforeAfterConfigs[picName][0] is not None and self.beforeAfterConfigs[picName][1] is not None:
+            # write out the configs
+            self.beforeAfterFile.write("\t {0}-{1} Before\n".format(picName, interface))
+            #
+            # This is I/O bottle-necked. A bulk write() would be more efficient, or writelines(). writelines() doesn't
+            # append new lines though.
+            #
+            for line in self.beforeAfterConfigs[picName][0]:
+                self.beforeAfterFile.write(line + '\n')
+            self.beforeAfterFile.write("\t {0}-{1} After\n".format(picName, interface))
+            for line in self.beforeAfterConfigs[picName][1]:
+                self.beforeAfterFile.write(line + '\n')
+            self.beforeAfterConfigs[picName] = None
+            self.beforeAfterFile.flush()
 
     def logSuccess(self, string, echo):
         self.logFile.write("|{0}| SUCCESS - {1}\n".format(self.getTimeStamp(), string))
@@ -125,13 +185,16 @@ class Logger:
         if self.logFile is not sys.stdout:
             self.logFile.close()
             self.sshLogFile.close()
+            self.beforeAfterFile.close()
 
     @staticmethod
     def getTimeStamp():
         localtime = time.localtime(time.time())
-        pm = (False, True)[localtime.tm_hour > 11]
+        # pm = (False, True)[localtime.tm_hour > 11]
+        pm = True if localtime.tm_hour > 11 else False
+        hourFixed = localtime.tm_hour % 12 if localtime.tm_hour != 12 else localtime.tm_hour % 12 + 1
         minFixed = ("0{0}".format(localtime.tm_min), str(localtime.tm_min))[localtime.tm_min > 9]
-        return "{0}:{1} {2}".format(localtime.tm_hour % 12, minFixed, ("AM", "PM")[pm])
+        return "{0}:{1} {2}".format(hourFixed, minFixed, ("AM", "PM")[pm])
 
     @staticmethod
     def StdoutLogger():

--- a/Logger.py
+++ b/Logger.py
@@ -192,7 +192,7 @@ class Logger:
         localtime = time.localtime(time.time())
         # pm = (False, True)[localtime.tm_hour > 11]
         pm = True if localtime.tm_hour > 11 else False
-        hourFixed = localtime.tm_hour % 12 if localtime.tm_hour != 12 else localtime.tm_hour % 12 + 1
+        hourFixed = localtime.tm_hour % 12 if localtime.tm_hour != 12 else 12
         minFixed = ("0{0}".format(localtime.tm_min), str(localtime.tm_min))[localtime.tm_min > 9]
         return "{0}:{1} {2}".format(hourFixed, minFixed, ("AM", "PM")[pm])
 

--- a/Logger.py
+++ b/Logger.py
@@ -28,7 +28,7 @@ class Logger:
             self.sshLogFile = sys.stdout
         else:
             if logFolder is None:
-                self.logFolder = Common.getUserHome() + "larry/logs/"
+                self.logFolder = Common.getUserHome() + Common.dataDirectory + "/logs/"
             else:
                 self.logFolder = logFolder
             self.ticketFolder = self.logFolder + str(ticketNumber) + "/"

--- a/PersistenceModule.py
+++ b/PersistenceModule.py
@@ -19,7 +19,7 @@ class PersistenceModule:
     def __init__(self):
         if self.DISABLED:
             return
-        self.persistenceFile = Common.getUserHome() + 'larry/' + Common.persistenceFile
+        self.persistenceFile = Common.getUserHome() + Common.dataDirectory + Common.persistenceFile
         if os.path.exists(self.persistenceFile):
             # try and load session info
             try:

--- a/PersistenceModule.py
+++ b/PersistenceModule.py
@@ -86,6 +86,8 @@ class PersistenceModule:
             jsonStr = json.dumps(data)
             key = self.__createKey()
             ciphertext = self.encrypt(jsonStr, key)
+            if not os.path.isdir(Common.getUserHome() + Common.dataDirectory):
+                os.mkdir(Common.getUserHome() + Common.dataDirectory)
             f = open(self.persistenceFile, "w+")
             f.write(ciphertext)
             ConfigurationDriver.loadedSession = True

--- a/TODO
+++ b/TODO
@@ -12,4 +12,4 @@ Bugs
 - Handle socket timeout where a switch takes a long time to respond, but is responding (Adaptive-timeout)
 - PersistenceModule breaks util/scraper [FIXED]
 - Mac Address Table gets truncated for long row counts (e.g. Po1)
-- Verify fails when port is shutdown (Ticket is a verify but really it should be an activate)
+- Modify fails when port is shutdown (Ticket is a modify but really it should be an activate) [FIXED]

--- a/UI.py
+++ b/UI.py
@@ -5,6 +5,7 @@ import signal
 from ui import art
 from paramiko import AuthenticationException
 from PasswordUtility import PasswordUtility
+import traceback
 
 
 class UI:
@@ -42,7 +43,9 @@ class UI:
                 self.goToMainPage()
             except StopIteration:
                 self.goToMainPage()
-            except Exception:
+            except Exception, e:
+                print e
+                print traceback.format_exc()
                 self.goToMainPage()
 
     def work_page(self):

--- a/larry.py
+++ b/larry.py
@@ -40,7 +40,8 @@ class larry:
         print "  -noLogging, --noLogging\t\tTurns off debug logging"
         print "  -disableVrf, --disableVrf\t\tDisables larry's VRF workaround"
         print "  -disableColor, --disableColor\t\tDisable color output"
-        print "  -h, -h\t\t\t\tDisplays this help screen"
+        print "  -disablePM, --disablePM\t\tDisables the Persistence Module"
+        print "  -h, --h\t\t\t\tDisplays this help screen"
 
     def parseArgs(self):
         for arg in sys.argv:
@@ -58,6 +59,8 @@ class larry:
                 Common.vrfDisabled = True
             elif arg == "--disableColor" or arg == "-disableColor":
                 Logger.disableColor = True
+            elif arg == "--disablePM" or arg == "-disablePM":
+                self.disablePersistence = True
             elif arg == "--h" or arg == "-h":
                 self.showHelp()
                 exit(1)

--- a/procedures/Config.py
+++ b/procedures/Config.py
@@ -94,6 +94,7 @@ class Config:
         speed = iosConnection.getSpeed(interface, switchConfig)
         voiceVlan = iosConnection.getVoiceVlan(interface, switchConfig)
         description = iosConnection.getDescription(interface, switchConfig)
+        shutdown = iosConnection.isShutdown(interface, switchConfig)
         if description is None or description != pic.getDescription():
             # print "DESCRIPTIONS DON'T MATCH ON MODIFY - PIC: {0}, provider: {1}".format(pic.name, provider)
             self.logger.logWarning("DESCRIPTIONS DON'T MATCH ON MODIFY - PIC: {0}, provider: {1}".format(pic.name, provider), True)
@@ -110,6 +111,10 @@ class Config:
                 self.hostChanged = True
         if speed is None or speed.speedTuple != risqueConfig.speed.speedTuple:
             iosConnection.setSpeed(risqueConfig.speed)
+            self.hostChanged = True
+        if shutdown:
+            self.logger.logWarning("INTERFACE IS SHUTDOWN ON A MODIFY, ENABLING THE PORT - PIC: {0}, provider: {1}".format(pic.name, provider), True)
+            iosConnection.shutdown(no=True)
             self.hostChanged = True
         iosConnection.leaveInterfaceConfig()
         iosConnection.leaveConfigMode()
@@ -128,6 +133,7 @@ class Config:
         speed = iosConnection.getSpeed(interface, switchConfig)
         voiceVlan = iosConnection.getVoiceVlan(interface, switchConfig)
         description = iosConnection.getDescription(interface, switchConfig)
+        shutdown = iosConnection.isShutdown(interface, switchConfig)
         if description is None or description != pic.getDescription():
             # print "DESCRIPTIONS DON'T MATCH ON MODIFY - PIC: {0}, provider: {1}".format(pic.name, provider)
             self.logger.logWarning(
@@ -166,6 +172,11 @@ class Config:
             if len(vlans) > 0:
                 iosConnection.addTaggedVlans(vlans)
                 self.hostChanged = True
+
+        if shutdown:
+            self.logger.logWarning("INTERFACE IS SHUTDOWN ON A MODIFY, ENABLING THE TRUNK PORT - PIC: {0}, provider: {1}".format(pic.name, provider), True)
+            iosConnection.shutdown(no=True)
+            self.hostChanged = True
 
         iosConnection.leaveInterfaceConfig()
         iosConnection.leaveConfigMode()

--- a/procedures/Config.py
+++ b/procedures/Config.py
@@ -24,6 +24,7 @@ class Config:
         else:
             interface = provider.getSwitchInterface()
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        self.logger.logBefore(pic.name, interface, switchConfig)
         description = iosConnection.getDescription(interface, switchConfig)
         if description is None or description != pic.getDescription():
             # print "DESCRIPTIONS DON'T MATCH ON MODIFY - PIC: {0}, provider: {1}".format(pic.name, provider)
@@ -51,6 +52,7 @@ class Config:
         risqueConfig = pic.getConfig()
 
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        self.logger.logBefore(pic.name, interface, switchConfig)
 
         if provider.uplink:
             # print "Provider is an uplink port, not supported yet!"
@@ -90,6 +92,7 @@ class Config:
             interface = provider.getSwitchInterface()
         risqueConfig = pic.getConfig()
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        self.logger.logBefore(pic.name, interface, switchConfig)
         vlan = iosConnection.getVlan(interface, switchConfig)
         speed = iosConnection.getSpeed(interface, switchConfig)
         voiceVlan = iosConnection.getVoiceVlan(interface, switchConfig)
@@ -127,6 +130,7 @@ class Config:
             return False
         risqueConfig = pic.getConfig()
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        self.logger.logBefore(pic.name, interface, switchConfig)
         switchMode = iosConnection.getSwitchportMode(interface, switchConfig)
         nativeVlan = iosConnection.getNativeVlan(interface, switchConfig)
         taggedVlans = iosConnection.getTaggedVlans(interface, switchConfig)
@@ -189,6 +193,7 @@ class Config:
             return False
         risqueConfig = pic.getConfig()
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        self.logger.logBefore(pic.name, interface, switchConfig)
         switchMode = iosConnection.getSwitchportMode(interface, switchConfig)
 
         iosConnection.enterConfigMode()
@@ -212,6 +217,7 @@ class Config:
             self.logger.logError("Can't modify trunk port on a FEX host")
             return False
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        self.logger.logBefore(pic.name, interface, switchConfig)
         description = iosConnection.getDescription(interface, switchConfig)
         if description is None or description != pic.getDescription():
             self.logger.logError("Can't modify trunk port on a FEX host")

--- a/procedures/Verify.py
+++ b/procedures/Verify.py
@@ -23,6 +23,7 @@ class Verify:
         else:
             interface = provider.getSwitchInterface()
         switchConfig = iosConnection.getConfig(interface)
+        self.logger.logAfter(pic.name, interface, switchConfig)
         if switchConfig is None:
             # print "{0} - Failed to get config".format(pic.name)
             self.logger.logError("{0} - Failed to get config".format(pic.name), True)
@@ -55,6 +56,7 @@ class Verify:
         else:
             interface = provider.getSwitchInterface()
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        self.logger.logAfter(pic.name, interface, switchConfig)
         if switchConfig is None:
             # print "{0} - Failed to get config".format(pic.name)
             self.logger.logError("{0} - Failed to get config".format(pic.name), True)
@@ -116,6 +118,7 @@ class Verify:
     def __verifyTrunkDeactivate(self, iosConnection, provider, pic):
         interface = provider.getSwitchInterface()
         switchConfig = iosConnection.getConfig(interface)
+        self.logger.logAfter(pic.name, interface, switchConfig)
         if switchConfig is None:
             # print "{0} - Failed to get config".format(pic.name)
             self.logger.logError("{0} - Failed to get config".format(pic.name), True)
@@ -146,6 +149,7 @@ class Verify:
     def __verifyTrunkWork(self, iosConnection, provider, pic):
         interface = provider.getSwitchInterface()
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        self.logger.logAfter(pic.name, interface, switchConfig)
         risqueConfig = pic.getConfig()
         if switchConfig is None:
             # print "{0} - Failed to get config".format(pic.name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 lxml
 BeautifulSoup4
 paramiko
+simple-crypt


### PR DESCRIPTION
- Added Before/After Logging (logs the configuration before any changes are applied and after changes are applied)
- Moved logs folder and the persistence file from ```larry/``` to ```larry-data/```
     - Logs and persistence file would be erased per each update, ```shutil.rmtree()``` does not allow an ignore flag
     - ```larry-data``` was the compromise between backing files individually during the install/upgrade procedure and just deleting files per upgrade
- Modifies will now check if the port is shutdown and enable the port if it is.
     - Like an invalid description, the Modify procedure will warn the user that the port is shutdown and is now being enabled
- Fixed Bugs (12:00 AM/PM will now show up as 12:00 and not 0:00)