### PR TITLE
Hotfix

### DIFF
--- a/procedures/Verify.py
+++ b/procedures/Verify.py
@@ -99,7 +99,7 @@ class Verify:
             if voiceVlan is None:
                 self.logger.logWarning("{0} does not have a voice vlan".format(pic.name), True)
             else:
-                self.logger.logInfo("{0} has voice vlan {1}".format(pic.name, voiceVlan))
+                self.logger.logInfo("{0} has voice vlan {1}".format(pic.name, voiceVlan), True)
         # Check description
         if description != pic.getDescription():
             # print "{0} - incorrect description".format(pic.name)


### PR DESCRIPTION
Fixing
Traceback (most recent call last):
  File "/home/ONEPURDUE/everettr/larry/procedures/Verify.py", line 316, in run
    if not self.verify(iosConnection, provider, pic):
  File "/home/ONEPURDUE/everettr/larry/procedures/Verify.py", line 252, in verify
    return self.__verifyBasicWork(iosConnection, provider, pic)
  File "/home/ONEPURDUE/everettr/larry/procedures/Verify.py", line 102, in __verifyBasicWork
    self.logger.logInfo("{0} has voice vlan {1}".format(pic.name, voiceVlan))
TypeError: logInfo() takes exactly 3 arguments (2 given)