### PR TITLE
VoIP Vlan

### DIFF
--- a/Logger.py
+++ b/Logger.py
@@ -165,7 +165,7 @@ class Logger:
     def getInstance(ticketNumber):
         if ticketNumber is None:
             if Logger.instance is None:
-                print Logger.FAIL + "Can't get singleton instance having not been initialized first" + Logger.NORMAL
+                # print Logger.FAIL + "Can't get singleton instance having not been initialized first" + Logger.NORMAL
                 return Logger.StdoutLogger()
             else:
                 return Logger.instance

--- a/PIC.py
+++ b/PIC.py
@@ -27,6 +27,9 @@ class PICConfig:
         self.speed = Speed(risqueString=speed)
 
     def addVoiceVlan(self, voiceVlan):
+        if isinstance(voiceVlan, Vlan):
+            self.voiceVlan = voiceVlan
+            return
         if type(voiceVlan) is not str:
             raise AttributeError("addVoiceVlan given null attributes")
         self.voiceVlan = Vlan(risqueString=voiceVlan)
@@ -93,6 +96,11 @@ class PIC:
         self.newConfig = PICConfig(vlan, speed)
         if voiceVlan is not None:
             self.newConfig.addVoiceVlan(voiceVlan)
+        else:
+            # voice vlan is None
+            if self.currentConfig is not None and self.currentConfig.voiceVlan is not None:
+                print "New config doesn't have a voice vlan but current config does, using old voice vlan"
+                self.newConfig.addVoiceVlan(self.currentConfig.voiceVlan)
 
     def __isValidAction(self):
         if self.action == "Activate":

--- a/Ssh.py
+++ b/Ssh.py
@@ -21,8 +21,8 @@ class Ssh:
     expected = ""
     SSH_DISALLOWED_HOSTS = ["lynn-sbpe", "erht-sbpe"]   # itap-iape and lamb-sbpe have FEX ports
     SSH_FEX_HOST = ["itap-iape", "lamb-sbpe"]
-    SSH_TIMEOUT = 30                                     # avoid forever waiting for ssh
-    SSH_VRF_TIMEOUT = 10                                  # reduce timeout for vrf
+    SSH_TIMEOUT = 60                                     # avoid forever waiting for ssh
+    SSH_VRF_TIMEOUT = 20                                  # reduce timeout for vrf
     SSH_DIRTY_COMMAND = 'ls'
     vrfAffected = False
 

--- a/UI.py
+++ b/UI.py
@@ -20,7 +20,7 @@ class UI:
         self.pages = [
             ["Do Ticket", self.work_page],
             ["Verify Ticket", self.verify_page],
-            # ["Store Credentials", self.credentials_page],
+            ["Store Credentials", self.credentials_page],
             ["Exit", self.exit],
             ["Art", self.artPage]
         ]

--- a/procedures/Config.py
+++ b/procedures/Config.py
@@ -79,6 +79,12 @@ class Config:
             iosConnection.setVoiceVlan(risqueConfig.voiceVlan)
         else:
             self.logger.logWarning("Risque does not have a voice vlan for {0}".format(pic.name), True)
+            switchGlobalVoiceVlan = iosConnection.findVoiceVlan()
+            if switchGlobalVoiceVlan is None:
+                self.logger.logError("Unable to retrieve voice vlan for switch", False)
+            else:
+                iosConnection.setVoiceVlan(switchGlobalVoiceVlan)
+                self.logger.logInfo("Set voice vlan for {0} to {1}".format(pic.name, switchGlobalVoiceVlan), False)
         # Set no shut
         iosConnection.shutdown(no=True)
 
@@ -116,6 +122,14 @@ class Config:
                 self.hostChanged = True
         else:
             self.logger.logWarning("Risque does not have a voice vlan for {0}".format(pic.name), True)
+            switchGlobalVoiceVlan = iosConnection.findVoiceVlan()
+            if switchGlobalVoiceVlan is None:
+                self.logger.logError("Unable to retrieve voice vlan for switch", False)
+            # If voice vlan already exists on switch, ignore and continue
+            # else add globalvoicevlan to interface
+            if voiceVlan is None and switchGlobalVoiceVlan is not None:
+                iosConnection.setVoiceVlan(switchGlobalVoiceVlan)
+                self.logger.logInfo("Set voice vlan for {0} to {1}".format(pic.name, switchGlobalVoiceVlan), False)
         if speed is None or speed.speedTuple != risqueConfig.speed.speedTuple:
             iosConnection.setSpeed(risqueConfig.speed)
             self.hostChanged = True

--- a/procedures/Verify.py
+++ b/procedures/Verify.py
@@ -96,10 +96,19 @@ class Verify:
                 passed = False
         else:
             self.logger.logWarning("Risque doesn't have a voice vlan", True)
+            switchGlobalVoiceVlan = iosConnection.findVoiceVlan()
             if voiceVlan is None:
-                self.logger.logWarning("{0} does not have a voice vlan".format(pic.name), True)
+                if switchGlobalVoiceVlan is not None:
+                    self.logger.logError("{0} does not have a voice vlan".format(pic.name), True)
+                    passed = False
             else:
-                self.logger.logInfo("{0} has voice vlan {1}".format(pic.name, voiceVlan), True)
+                # self.logger.logInfo("{0} has voice vlan {1}".format(pic.name, voiceVlan), True)
+                # check if globalvoicevlan and current voice vlan are the same
+                if switchGlobalVoiceVlan == str(voiceVlan.tag):
+                    self.logger.logInfo("Voice vlan for {0} is {1}".format(pic.name, switchGlobalVoiceVlan), True)
+                else:
+                    self.logger.logWarning("{0} has a different voice vlan ({1}) than the switch's 'global' voice vlan({2})"
+                                           .format(pic.name, voiceVlan.tag, switchGlobalVoiceVlan), True)
         # Check description
         if description != pic.getDescription():
             # print "{0} - incorrect description".format(pic.name)


### PR DESCRIPTION
- Deal with VoIP vlan not being present on Risque
    Configure: get the 'global' vlan from the switch to configure the interface with
    Verify: Fail if VoIP vlan isn't present (by default), handle differences between global, interface, and risque vlans
- If new config doesn't have a VoIP vlan attached, use the one from the current config