### PR TITLE
0.5 Release

### DIFF
--- a/Hosts.py
+++ b/Hosts.py
@@ -136,31 +136,14 @@ class Hosts:
             "c9348uxm",
         }
 
-    @staticmethod
-    def getUPSList():
-        return {
-            "apc1500",
-            "apc1500rm",
-            "apc3000",
-            "apc3000rm",
-            "apc5000",
-            "apc5000rm",
-            "apc6000",
-            "apc6000rm",
-            "apc750",
-            "trp1500",
-            "trp6000"
-        }
-
     #  Removes all but (if true) switches and (if true) chassis
     #  if vlan, don't reject vlan hosts
     @staticmethod
-    def filter(hostList, room, switches=False, chassis=False, vlan=False, ups=False):
+    def filter(hostList, room, switches=False, chassis=False, vlan=False):
         Switches = Hosts.getSwitchList()
         Chassis = Hosts.getChassisList()
-        UPSs = Hosts.getUPSList()
-        if not isinstance(switches, bool) or not isinstance(chassis, bool) or not isinstance(vlan, bool) or not isinstance(ups, bool):
-            print("filter() was given non-boolean parameters")
+        if not isinstance(switches, bool) or not isinstance(chassis, bool) or not isinstance(vlan, bool):
+            print("filter() was give non-boolean parameters")
             return None
         if not isinstance(hostList, dict):
             print("filter() was given a non-dict parameter")
@@ -193,21 +176,6 @@ class Hosts:
                         if buildingName not in newHosts:
                             newHosts[buildingName] = list()
                         newHosts[buildingName].append(value)
-                if vlan and "vlan" in value:
-                    if buildingName not in newHosts:
-                        newHosts[buildingName] = list()
-                    newHosts[buildingName].append(value)
-                if ups:
-                    fixedDevice = None
-                    if "r" in device or "m" in device:
-                        fixedDevice = device[0:device.rfind('0')+1]
-                    else:
-                        fixedDevice = device
-                    if fixedDevice in UPSs:
-                        if buildingName not in newHosts:
-                            newHosts[buildingName] = list()
-                        newHosts[buildingName].append(value)
-
         return newHosts
 
     # Return hostname
@@ -294,37 +262,6 @@ class Hosts:
         itapIp = Hosts.getIPAddressOfHost('itap-iape-01.tcom.purdue.edu')
         print "itap-iape IP: {0}".format(itapIp)
         return itapIp == ip
-
-    @staticmethod
-    # Returns true if the host is a UPS device or not
-    def isUPS(host):
-        return Hosts.hostToUPSDevice(host) is not None
-
-    @staticmethod
-    # returns the
-    def hostToUPSDevice(host):
-        # host = stew-215a-apc1500r
-        if host is None or len(host) == 0:
-            return None
-        # ['stew', '215a', 'apc1500r']
-        hostSplit = host.split('-')
-        if len(hostSplit) < 3:
-            return None
-        upsDevice = hostSplit[2]
-        if "r" in upsDevice or "m" in upsDevice:
-            # remove trailing qualifiers (apc1500rm -> apc1500)
-            lastZero = upsDevice.rfind('0')
-            upsDevice = upsDevice[0:lastZero + 1]
-        device = None
-        for host in Hosts.getUPSList():
-            if upsDevice == host:
-                device = upsDevice
-                break
-        if device is None:
-            return None
-        if "apc" in device and not "rm" in device:
-            return device + "rm"
-        return device
 
 
 class OSException(Exception):

--- a/Hosts.py
+++ b/Hosts.py
@@ -139,10 +139,14 @@ class Hosts:
     @staticmethod
     def getUPSList():
         return {
+            "apc1500",
             "apc1500rm",
             "apc3000",
+            "apc3000rm",
             "apc5000",
+            "apc5000rm",
             "apc6000",
+            "apc6000rm",
             "apc750",
             "trp1500",
             "trp6000"
@@ -194,7 +198,12 @@ class Hosts:
                         newHosts[buildingName] = list()
                     newHosts[buildingName].append(value)
                 if ups:
-                    if device in UPSs:
+                    fixedDevice = None
+                    if "r" in device or "m" in device:
+                        fixedDevice = device[0:device.rfind('0')+1]
+                    else:
+                        fixedDevice = device
+                    if fixedDevice in UPSs:
                         if buildingName not in newHosts:
                             newHosts[buildingName] = list()
                         newHosts[buildingName].append(value)
@@ -285,6 +294,37 @@ class Hosts:
         itapIp = Hosts.getIPAddressOfHost('itap-iape-01.tcom.purdue.edu')
         print "itap-iape IP: {0}".format(itapIp)
         return itapIp == ip
+
+    @staticmethod
+    # Returns true if the host is a UPS device or not
+    def isUPS(host):
+        return Hosts.hostToUPSDevice(host) is not None
+
+    @staticmethod
+    # returns the
+    def hostToUPSDevice(host):
+        # host = stew-215a-apc1500r
+        if host is None or len(host) == 0:
+            return None
+        # ['stew', '215a', 'apc1500r']
+        hostSplit = host.split('-')
+        if len(hostSplit) < 3:
+            return None
+        upsDevice = hostSplit[2]
+        if "r" in upsDevice or "m" in upsDevice:
+            # remove trailing qualifiers (apc1500rm -> apc1500)
+            lastZero = upsDevice.rfind('0')
+            upsDevice = upsDevice[0:lastZero + 1]
+        device = None
+        for host in Hosts.getUPSList():
+            if upsDevice == host:
+                device = upsDevice
+                break
+        if device is None:
+            return None
+        if "apc" in device and not "rm" in device:
+            return device + "rm"
+        return device
 
 
 class OSException(Exception):

--- a/Hosts.py
+++ b/Hosts.py
@@ -136,14 +136,27 @@ class Hosts:
             "c9348uxm",
         }
 
+    @staticmethod
+    def getUPSList():
+        return {
+            "apc1500rm",
+            "apc3000",
+            "apc5000",
+            "apc6000",
+            "apc750",
+            "trp1500",
+            "trp6000"
+        }
+
     #  Removes all but (if true) switches and (if true) chassis
     #  if vlan, don't reject vlan hosts
     @staticmethod
-    def filter(hostList, room, switches=False, chassis=False, vlan=False):
+    def filter(hostList, room, switches=False, chassis=False, vlan=False, ups=False):
         Switches = Hosts.getSwitchList()
         Chassis = Hosts.getChassisList()
-        if not isinstance(switches, bool) or not isinstance(chassis, bool) or not isinstance(vlan, bool):
-            print("filter() was give non-boolean parameters")
+        UPSs = Hosts.getUPSList()
+        if not isinstance(switches, bool) or not isinstance(chassis, bool) or not isinstance(vlan, bool) or not isinstance(ups, bool):
+            print("filter() was given non-boolean parameters")
             return None
         if not isinstance(hostList, dict):
             print("filter() was given a non-dict parameter")
@@ -176,6 +189,16 @@ class Hosts:
                         if buildingName not in newHosts:
                             newHosts[buildingName] = list()
                         newHosts[buildingName].append(value)
+                if vlan and "vlan" in value:
+                    if buildingName not in newHosts:
+                        newHosts[buildingName] = list()
+                    newHosts[buildingName].append(value)
+                if ups:
+                    if device in UPSs:
+                        if buildingName not in newHosts:
+                            newHosts[buildingName] = list()
+                        newHosts[buildingName].append(value)
+
         return newHosts
 
     # Return hostname

--- a/IOS.py
+++ b/IOS.py
@@ -663,7 +663,11 @@ class IOS:
         if self.voiceVlan is not None:
             return self.voiceVlan
         else:
-            result = self.sshClient.execute('show running-config | i switchport voice vlan')[0]
+            result = self.sshClient.execute('show running-config | i switchport voice vlan')
+            if result is None:
+                return None
+            else:
+                result = result[0]
             lines = result.split('\n')
             if len(lines) == 0:
                 return None

--- a/IOS.py
+++ b/IOS.py
@@ -663,7 +663,7 @@ class IOS:
         if self.voiceVlan is not None:
             return self.voiceVlan
         else:
-            result = self.sshClient.execute('show running-config | i switchport voice vlan')
+            result = self.sshClient.execute('show running-config | i switchport voice vlan', noMore=True)
             if result is None:
                 return None
             else:

--- a/PIC.py
+++ b/PIC.py
@@ -2,6 +2,7 @@ from Speed import Speed
 from Vlan import Vlan
 from Provider import Provider
 from Patch import Patch
+import re
 
 
 class PICConfig:
@@ -61,6 +62,8 @@ class PIC:
     action = None
     trunk = False
     patch = None
+    apRegex = re.compile("(AP-)[A-z]+")
+    upsRegex = re.compile("[A-z-0-9]+(HW-UPS)")
 
     def __init__(self, name, currentProvider, newProvider, action, services):
         # if name is None or newProvider is None or action is None:
@@ -166,3 +169,16 @@ class PIC:
 
     def getDescription(self):
         return self.name.lower()
+
+    def isAP(self):
+        # matches PICs of type BIDC-103AP-B but not of type BIDC-103A-AP
+        return self.apRegex.match(self.name) is not None
+
+    def isUPS(self):
+        # matches PICs of type CREC-B318HW-UPS
+        return self.upsRegex.match(self.name) is not None
+
+    def getUPSName(self):
+        # return name of type yong-664-trp1500
+        provider = self.getProvider()
+

--- a/PIC.py
+++ b/PIC.py
@@ -172,7 +172,15 @@ class PIC:
 
     def isAP(self):
         # matches PICs of type BIDC-103AP-B but not of type BIDC-103A-AP
-        return self.apRegex.match(self.name) is not None
+        if self.apRegex.match(self.name) is not None:
+            return True
+        # check if vlan is 1001, see #70004 for an AP THAT DOESN'T FOLLOW THE STANDARD
+        config = self.getConfig()
+        if config is None:
+            return False
+        if isinstance(config.vlan, Vlan) and config.vlan.tag == 1001:
+            return True
+        return False
 
     def isUPS(self):
         # matches PICs of type CREC-B318HW-UPS

--- a/Provider.py
+++ b/Provider.py
@@ -167,3 +167,19 @@ class Provider:
             return "{0}0/{1}".format(self.intType, self.port)
         else:
             return "{0}{1}/{2}/{3}".format(self.intType, self.switch, (0, 1)[self.uplink], self.port)
+
+    def isValidUPSName(self, name):
+        # of type yong-664-trp1500-01
+        # check building name is same, check tr is same
+        # check ups model is a valid model
+        # ['yong', '664', 'trp1500', '01']
+        nameSplit = name.split('-')
+        if nameSplit is None or len(nameSplit) < 3:
+            return False
+        if nameSplit[0] != self.building:
+            return False
+        if nameSplit[1] != self.TR:
+            return False
+        if nameSplit[2] not in Hosts.getUPSList():
+            return False
+        return True

--- a/Provider.py
+++ b/Provider.py
@@ -159,6 +159,24 @@ class Provider:
                 return host
         return None
 
+    @staticmethod
+    # Assumes the TR has all the same types of UPSs (if more than one)
+    # Returns the first type found
+    def getUPSTypeFromProvider(provider):
+        if provider is None:
+            return None
+        if provider.building is None or provider.TR is None:
+            raise AttributeError("getUPSTypeFromProvider requires a valid building and room")
+        buildingList = Hosts.getBuildings(provider.building)
+        if provider.building not in buildingList:
+            raise ValueError("Invalid Building, unable to get host")
+        #  search by room and switch
+        filtered = Hosts.filter(buildingList, str(provider.TR), ups=True)
+        if filtered[provider.building] is None:
+            return None
+        # convert host (stew-115b-apc5000rm-01.tcom.purdue.edu) to device (apc5000rm)
+        return Hosts.hostToUPSDevice(filtered[provider.building][0])
+
     # Returns an interface corresponding to this provider
     # e.g., gi3/0/1, te1/1/3, fa0/1, tw3/0/1
     def getSwitchInterface(self):

--- a/Speed.py
+++ b/Speed.py
@@ -164,7 +164,7 @@ class Speed:
     @staticmethod
     def SpeedAutoObject():
         speed = Speed()
-        speed.setDuplex(speed.DUPLEX_AUTO)
+        speed.duplex = Speed.DUPLEX_AUTO
         speed.__fillTuple()
         speed.speedAuto = True
         speed.isSpeedAutoObject = True

--- a/Speed.py
+++ b/Speed.py
@@ -11,6 +11,7 @@ class Speed:
     duplex = None       # auto, full, half
     speedTuple = None   # 10, 100, 1000, 2500, 5000, 10000
     speedAuto = False
+    isSpeedAutoObject = False
     noSpeed = False
 
     def __init__(self, name=None, risqueString=None, switchString=None):
@@ -166,6 +167,7 @@ class Speed:
         speed.setDuplex(speed.DUPLEX_AUTO)
         speed.__fillTuple()
         speed.speedAuto = True
+        speed.isSpeedAutoObject = True
         return speed
 
     # Fills the speed Tuple
@@ -215,6 +217,8 @@ class Speed:
             raise AttributeError("Speed::switchCommand() given invalid arguments")
         if speed.noSpeed:
             return "no speed auto"
+        if speed.isSpeedAutoObject:
+            return "speed auto"
         base = "speed "
         speeds = ""
         count = 0

--- a/Speed.py
+++ b/Speed.py
@@ -233,3 +233,14 @@ class Speed:
         speed.__fillTuple()
         speed.noSpeed = True
         return speed
+
+    @staticmethod
+    def resolveDuplexFromSwitch(duplex):
+        if duplex is None or not isinstance(duplex, str) or len(duplex) == 0:
+            return None
+        if "full" in duplex:
+            return Speed.DUPLEX_FULL
+        elif "half" in duplex:
+            return Speed.DUPLEX_HALF
+        else:
+            return Speed.DUPLEX_AUTO

--- a/TODO
+++ b/TODO
@@ -3,6 +3,7 @@
 - Check Repairs [IMPLEMENTED]
     - If connected
     - Else, check for mac addresses
+SERVICES Ticket #70065
 Bugs
 - Check if a host is retrieved from Provider.getHostFromProvider before executing [FIXED]
 - Executing an invalid command on a VRF affected host doesn't include Invalid Input error

--- a/procedures/Config.py
+++ b/procedures/Config.py
@@ -52,12 +52,17 @@ class Config:
         risqueConfig = pic.getConfig()
 
         switchConfig = iosConnection.getConfig(interface, flatten=False)
+        upsCount = 0
+        upsDevice = None
         self.logger.logBefore(pic.name, interface, switchConfig)
 
         if provider.uplink:
             # print "Provider is an uplink port, not supported yet!"
             self.logger.logError("Provider is an uplink port, not supported yet!", True)
             return
+        if pic.isUPS():
+            upsCount = iosConnection.getUPSCount()
+            upsDevice = provider.getUPSTypeFromProvider(provider)
 
         iosConnection.enterConfigMode()
         iosConnection.enterInterfaceConfig(interface)
@@ -67,11 +72,28 @@ class Config:
             iosConnection.applyBaseTemplate(iosConnection.getBaseTemplate())
 
         # Set Description
-        iosConnection.setDescription(pic.getDescription())
+        if pic.isUPS():
+            # 70136
+            # stew-215a-apc1500rm-01
+            fixedUPSCount = "0{0}".format(upsCount + 1) if (upsCount + 1) < 10 else str(upsCount + 1) # add leading zeroes
+            newDescription = "{0}-{1}-{2}-{3}".format(provider.building, provider.TR, upsDevice, fixedUPSCount)
+            iosConnection.setDescription(newDescription)
+        else:
+            iosConnection.setDescription(pic.getDescription())
         # Set access mode
         iosConnection.setSwitchportMode("access")
         # Set speed
-        iosConnection.setSpeed(risqueConfig.speed)
+        if pic.isAP():
+            if "Gi" in provider.intType:
+                iosConnection.setSpeed(risqueConfig.speed)
+                # set duplex
+                iosConnection.setDuplex(Speed.DUPLEX_FULL)
+            elif "Te" in provider.intType or "Tw" in provider.intType:
+                iosConnection.setSpeed(Speed.SpeedAutoObject())
+            else:
+                iosConnection.setSpeed(risqueConfig.speed)
+        else:
+            iosConnection.setSpeed(risqueConfig.speed)
         # Set vlan
         iosConnection.setVlan(risqueConfig.vlan)
         # Set voice vlan
@@ -85,6 +107,9 @@ class Config:
             else:
                 iosConnection.setVoiceVlan(switchGlobalVoiceVlan)
                 self.logger.logInfo("Set voice vlan for {0} to {1}".format(pic.name, switchGlobalVoiceVlan), False)
+        # set power for AP
+        if pic.isAP() and "3750" in provider.switchType:
+            iosConnection.setPower(20000)
         # Set no shut
         iosConnection.shutdown(no=True)
 
@@ -106,7 +131,7 @@ class Config:
         voiceVlan = iosConnection.getVoiceVlan(interface, switchConfig)
         description = iosConnection.getDescription(interface, switchConfig)
         shutdown = iosConnection.isShutdown(interface, switchConfig)
-        if description is None or description != pic.getDescription():
+        if not pic.isUPS and (description is None or description != pic.getDescription()):
             # print "DESCRIPTIONS DON'T MATCH ON MODIFY - PIC: {0}, provider: {1}".format(pic.name, provider)
             self.logger.logWarning("DESCRIPTIONS DON'T MATCH ON MODIFY - PIC: {0}, provider: {1}".format(pic.name, provider), True)
 

--- a/procedures/Config.py
+++ b/procedures/Config.py
@@ -55,6 +55,7 @@ class Config:
         upsCount = 0
         upsDevice = None
         self.logger.logBefore(pic.name, interface, switchConfig)
+        switchGlobalVoiceVlan = iosConnection.findVoiceVlan()
 
         if provider.uplink:
             # print "Provider is an uplink port, not supported yet!"
@@ -101,7 +102,6 @@ class Config:
             iosConnection.setVoiceVlan(risqueConfig.voiceVlan)
         else:
             self.logger.logWarning("Risque does not have a voice vlan for {0}".format(pic.name), True)
-            switchGlobalVoiceVlan = iosConnection.findVoiceVlan()
             if switchGlobalVoiceVlan is None:
                 self.logger.logError("Unable to retrieve voice vlan for switch", False)
             else:

--- a/procedures/Verify.py
+++ b/procedures/Verify.py
@@ -88,6 +88,7 @@ class Verify:
                 if duplex is None or duplex is not Speed.Speed.DUPLEX_FULL:
                     self.logger.logError("{0} - AP has incorrect duplex".format(pic.name), True)
                     self.logger.logError("\tswitch: {0}".format(duplex), True)
+                    passed = False
             # check for speed auto on Te/Tw ports, else check speed matches
             if "Te" in provider.intType or "Tw" in provider.intType:
                 # getSpeed returns None if speed auto
@@ -161,7 +162,7 @@ class Verify:
         if pic.isAP():
             # check power on 3750s
             if "3750" in provider.switchType:
-                power = iosConnection.getPower()
+                power = iosConnection.getPower(interface, switchConfig)
                 if power is None or power != 20000:
                     self.logger.logError("{0} - AP has incorrect power for a 3750".format(pic.name), True)
                     self.logger.logError("\tswitch: {0}".format(power), True)

--- a/procedures/Verify.py
+++ b/procedures/Verify.py
@@ -1,6 +1,7 @@
 from ConfigurationDriver import ConfigurationDriver
 from IOS import IOS
 from Vlan import Vlan
+import Speed
 import traceback
 from Logger import Logger
 
@@ -80,12 +81,34 @@ class Verify:
         mode = iosConnection.getSwitchportMode(interface, switchConfig)
         vlan = iosConnection.getVlan(interface, switchConfig)
         # Check speed
-        if speed is None or speed.speedTuple != risqueConfig.speed.speedTuple:
-            # print "{0} - incorrect speed".format(pic.name)
-            # print "\trisque: {0}, switch: {1}".format(risqueConfig.speed, speed)
-            self.logger.logError("{0} - incorrect speed".format(pic.name), True)
-            self.logger.logError("\trisque: {0}, switch: {1}".format(risqueConfig.speed, speed), True)
-            passed = False
+        if pic.isAP():
+            # check duplex on Gigabit Ports
+            if "Gi" in provider.intType:
+                duplex = iosConnection.getDuplex(interface, switchConfig)
+                if duplex is None or duplex is not Speed.Speed.DUPLEX_FULL:
+                    self.logger.logError("{0} - AP has incorrect duplex".format(pic.name), True)
+                    self.logger.logError("\tswitch: {0}".format(duplex), True)
+            # check for speed auto on Te/Tw ports, else check speed matches
+            if "Te" in provider.intType or "Tw" in provider.intType:
+                # getSpeed returns None if speed auto
+                if speed is not None:
+                    self.logger.logError("{0} - AP is not speed auto".format(pic.name), True)
+                    self.logger.logError("\tswitch: {0}".format(speed), True)
+                    passed = False
+            else:
+                if speed is None or speed.speedTuple != risqueConfig.speed.speedTuple:
+                    # print "{0} - incorrect speed".format(pic.name)
+                    # print "\trisque: {0}, switch: {1}".format(risqueConfig.speed, speed)
+                    self.logger.logError("{0} - AP has incorrect speed".format(pic.name), True)
+                    self.logger.logError("\trisque: {0}, switch: {1}".format(risqueConfig.speed, speed), True)
+                    passed = False
+        else:
+            if speed is None or speed.speedTuple != risqueConfig.speed.speedTuple:
+                # print "{0} - incorrect speed".format(pic.name)
+                # print "\trisque: {0}, switch: {1}".format(risqueConfig.speed, speed)
+                self.logger.logError("{0} - incorrect speed".format(pic.name), True)
+                self.logger.logError("\trisque: {0}, switch: {1}".format(risqueConfig.speed, speed), True)
+                passed = False
         # Check voice
         if risqueConfig.voiceVlan is not None:
             if voiceVlan is None or voiceVlan.tag != risqueConfig.voiceVlan.tag:
@@ -109,13 +132,20 @@ class Verify:
                 else:
                     self.logger.logWarning("{0} has a different voice vlan ({1}) than the switch's 'global' voice vlan({2})"
                                            .format(pic.name, voiceVlan.tag, switchGlobalVoiceVlan), True)
-        # Check description
-        if description != pic.getDescription():
-            # print "{0} - incorrect description".format(pic.name)
-            # print "\trisque: {0}, switch: {1}".format(pic.getDescription(), description)
-            self.logger.logError("{0} - incorrect description".format(pic.name), True)
-            self.logger.logError("\trisque: {0}, switch: {1}".format(pic.getDescription(), description), True)
-            passed = False
+        if pic.isUPS():
+            # check UPS has proper name
+            if not provider.isValidUPSName(description):
+                self.logger.logError("{0} - UPS has incorrect description".format(pic.name), True)
+                self.logger.logError("\tswitch: {1}".format(description), True)
+                passed = False
+        else:
+            # Check description
+            if description != pic.getDescription():
+                # print "{0} - incorrect description".format(pic.name)
+                # print "\trisque: {0}, switch: {1}".format(pic.getDescription(), description)
+                self.logger.logError("{0} - incorrect description".format(pic.name), True)
+                self.logger.logError("\trisque: {0}, switch: {1}".format(pic.getDescription(), description), True)
+                passed = False
         # Check mode
         if mode != "access":
             # print "{0} - switchport is not set to access mode".format(pic.name)
@@ -128,6 +158,15 @@ class Verify:
             self.logger.logError("{0} - incorrect vlan".format(pic.name), True)
             self.logger.logError("\trisque: {0}, switch: {1}".format(risqueConfig.vlan, vlan), True)
             passed = False
+        if pic.isAP():
+            # check power on 3750s
+            if "3750" in provider.switchType:
+                power = iosConnection.getPower()
+                if power is None or power != 20000:
+                    self.logger.logError("{0} - AP has incorrect power for a 3750".format(pic.name), True)
+                    self.logger.logError("\tswitch: {0}".format(power), True)
+                    passed = False
+
         return passed
 
     def __verifyTrunkDeactivate(self, iosConnection, provider, pic):


### PR DESCRIPTION
- Added support for activating UPSs and APs
     - Added Duplex and Power settings to the IOS class
     - Automatically picks the proper UPS model/number to use
     - Identifies APs that use the standard name as well as ones that are incorrectly named
- Added support for the Ssh client not having to request '--MORE--' every time
     - Should fix issues retrieving global voice vlan